### PR TITLE
Backport Alt and Down

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -1,3 +1,7 @@
+## Changes in 0.7.0
+ - Add functions and orphan instances introduced by changes to
+   `base-4.7.0.0` and `base-4.8.0.0`
+
 ## Changes in 0.6.0
  - Update `Prelude.Compat` for `base-4.8.0.0` and AMP
 

--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -1,3 +1,7 @@
+## Changes in 0.7.1
+ - Backported `Alt` to `Data.Monoid.Compat`
+ - Backported `Down` to `Data.Ord.Compat`
+
 ## Changes in 0.7.0
  - Add functions and orphan instances introduced by changes to
    `base-4.7.0.0` and `base-4.8.0.0`

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2012-2015 Simon Hengel <sol@typeful.net>
+Copyright (c) 2012-2015 Simon Hengel <sol@typeful.net> and Ryan Scott <ryan.gl.scott@ku.edu>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.markdown
+++ b/README.markdown
@@ -118,6 +118,7 @@ So far the following is covered.
  * `traceId`, `traceShowId`, `traceM`, and `traceShowM` functions to `Debug.Trace.Compat`
  * `calloc` and `callocBytes` functions to `Foreign.Marshal.Alloc.Compat`
  * `callocArray` and `callocArray0` functions to `Foreign.Marshal.Array.Compat`
+ * Backported `Down` data type to `Data.Ord`
 
 ## Supported versions of GHC/base
 

--- a/README.markdown
+++ b/README.markdown
@@ -118,6 +118,7 @@ So far the following is covered.
  * `traceId`, `traceShowId`, `traceM`, and `traceShowM` functions to `Debug.Trace.Compat`
  * `calloc` and `callocBytes` functions to `Foreign.Marshal.Alloc.Compat`
  * `callocArray` and `callocArray0` functions to `Foreign.Marshal.Array.Compat`
+ * Backported `Alt` data type to `Data.Monoid`
  * Backported `Down` data type to `Data.Ord`
 
 ## Supported versions of GHC/base

--- a/base-compat.cabal
+++ b/base-compat.cabal
@@ -23,8 +23,12 @@ library
       -Wall
   build-depends:
       base == 4.*
-    , ghc-prim
     , setenv
+
+  if impl(ghc >= 7.2) && impl(ghc < 7.6)
+    -- Prior to GHC 7.6, GHC.Generics lived in ghc-prim
+    build-depends: ghc-prim
+
   extensions:
       CPP
     , NoImplicitPrelude

--- a/base-compat.cabal
+++ b/base-compat.cabal
@@ -3,7 +3,8 @@ version:          0.7.0
 license:          MIT
 license-file:     LICENSE
 copyright:        (c) 2012-2015 Simon Hengel,
-                  (c) 2014 João Cristóvão
+                  (c) 2014 João Cristóvão,
+                  (c) 2015 Ryan Scott
 author:           Simon Hengel <sol@typeful.net>, João Cristóvão <jmacristovao@gmail.com>
 maintainer:       Simon Hengel <sol@typeful.net>, João Cristóvão <jmacristovao@gmail.com>
 build-type:       Simple

--- a/base-compat.cabal
+++ b/base-compat.cabal
@@ -23,12 +23,8 @@ library
       -Wall
   build-depends:
       base == 4.*
+    , ghc-prim
     , setenv
-
-  if impl(ghc >= 7.2) && impl(ghc < 7.6)
-    -- Prior to GHC 7.6, GHC.Generics lived in ghc-prim
-    build-depends: ghc-prim
-
   extensions:
       CPP
     , NoImplicitPrelude

--- a/base-compat.cabal
+++ b/base-compat.cabal
@@ -1,5 +1,5 @@
 name:             base-compat
-version:          0.7.0
+version:          0.7.1
 license:          MIT
 license-file:     LICENSE
 copyright:        (c) 2012-2015 Simon Hengel,

--- a/src/Control/Applicative/Compat.hs
+++ b/src/Control/Applicative/Compat.hs
@@ -2,8 +2,12 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Control.Applicative.Compat (
   module Base
+, Applicative(..)
+, Alternative(..)
 , Const(..)
 , WrappedMonad(..)
+, WrappedArrow(..)
+, ZipList(..)
 ) where
 import Control.Applicative as Base
 

--- a/src/Control/Exception/Compat.hs
+++ b/src/Control/Exception/Compat.hs
@@ -2,6 +2,7 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Control.Exception.Compat (
   module Base
+, ErrorCall(..)
 ) where
 
 import Control.Exception as Base

--- a/src/Control/Monad/Compat.hs
+++ b/src/Control/Monad/Compat.hs
@@ -1,5 +1,7 @@
 module Control.Monad.Compat (
   module Base
+, Monad(..)
+, MonadPlus(..)
 , void
 , (<$!>)
 ) where

--- a/src/Data/Bits/Compat.hs
+++ b/src/Data/Bits/Compat.hs
@@ -1,6 +1,7 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Data.Bits.Compat (
   module Base
+, Bits(..)
 ) where
 import Data.Bits as Base
 

--- a/src/Data/Functor/Compat.hs
+++ b/src/Data/Functor/Compat.hs
@@ -1,5 +1,6 @@
 module Data.Functor.Compat (
   module Base
+, Functor(..)
 , ($>)
 , void
 ) where

--- a/src/Data/Monoid/Compat.hs
+++ b/src/Data/Monoid/Compat.hs
@@ -1,4 +1,9 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving, StandaloneDeriving #-}
+
+#if __GLASGOW_HASKELL__ >= 702
+{-# LANGUAGE DeriveGeneric #-}
+#endif
+
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Data.Monoid.Compat (
         -- * Monoid typeclass

--- a/src/Data/Monoid/Compat.hs
+++ b/src/Data/Monoid/Compat.hs
@@ -4,6 +4,10 @@
 {-# LANGUAGE DeriveGeneric #-}
 #endif
 
+#if __GLASGOW_HASKELL__ >= 706
+{-# LANGUAGE PolyKinds #-}
+#endif
+
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Data.Monoid.Compat (
         -- * Monoid typeclass

--- a/src/Data/Monoid/Compat.hs
+++ b/src/Data/Monoid/Compat.hs
@@ -15,14 +15,24 @@ module Data.Monoid.Compat (
         -- * Maybe wrappers
         -- $MaybeExamples
         First(..),
-        Last(..)
+        Last(..),
+        -- * Alternative wrapper
+        Alt(..)
   ) where
 
 import Data.Monoid as Base
 
-#if !MIN_VERSION_base(4,7,0)
+-- To import orphan Generic instances for Sum and Product
 import GHC.Generics.Compat ()
-import Prelude.Compat (Num)
+
+#if !MIN_VERSION_base(4,8,0)
+import Control.Applicative (Alternative)
+import Control.Monad (MonadPlus)
+import Prelude.Compat
+
+# if __GLASGOW_HASKELL__ >= 702
+import GHC.Generics
+# endif
 #endif
 
 #if !MIN_VERSION_base(4,5,0)
@@ -39,4 +49,24 @@ infixr 6 <>
 #if !MIN_VERSION_base(4,7,0)
 deriving instance Num a => Num (Sum a)
 deriving instance Num a => Num (Product a)
+#endif
+
+#if !MIN_VERSION_base(4,8,0)
+-- | Monoid under '<|>'.
+--
+-- /Since: 4.8.0.0/
+newtype Alt f a = Alt {getAlt :: f a}
+  deriving ( Read, Show, Eq, Ord, Num, Enum
+           , Monad, MonadPlus, Applicative, Alternative, Functor
+# if __GLASGOW_HASKELL__ >= 702
+           , Generic
+# endif
+# if __GLASGOW_HASKELL__ >= 706
+           , Generic1
+# endif
+           )
+
+instance Alternative f => Monoid (Alt f a) where
+    mempty = Alt empty
+    mappend (Alt x) (Alt y) = Alt (x <|> y)
 #endif

--- a/src/Data/Monoid/Compat.hs
+++ b/src/Data/Monoid/Compat.hs
@@ -66,11 +66,6 @@ deriving instance Num a => Num (Product a)
 -- /Since: 4.8.0.0/
 newtype Alt f a = Alt {getAlt :: f a}
   deriving ( Read, Show, Eq, Ord, Num, Enum
--- Due to a bug in GHC 7.6, GeneralizedNewtypeDeriving breaks when deriving
--- poly-kinded data types.
-# if __GLASGOW_HASKELL__ >= 708
-            , Monad, MonadPlus, Applicative, Alternative, Functor
-# endif
 # if __GLASGOW_HASKELL__ >= 702
            , Generic
 # endif
@@ -79,27 +74,13 @@ newtype Alt f a = Alt {getAlt :: f a}
 # endif
            )
 
--- To work around a GHC 7.6 bug, we'll manually derive instances.
-# if __GLASGOW_HASKELL__ >= 706 && __GLASGOW_HASKELL__ < 708
-instance Functor f => Functor (Alt f) where
-    fmap f = Alt . fmap f . getAlt
-
-instance Applicative f => Applicative (Alt f) where
-    pure = Alt . pure
-    Alt f <*> Alt a = Alt (f <*> a)
-
-instance Monad m => Monad (Alt m) where
-    return = Alt . return
-    Alt x >>= f = Alt (x >>= getAlt . f)
-
-instance Alternative f => Alternative (Alt f) where
-    empty = Alt empty
-    Alt x <|> Alt y = Alt (x <|> y)
-
-instance MonadPlus m => MonadPlus (Alt m) where
-    mzero = Alt mzero
-    mplus (Alt x) (Alt y) = Alt (mplus x y)
-# endif
+-- To work around a GHC 7.6 bug, we'll use StandaloneDeriving for generalized
+-- derivations that involve higher-kinded typeclasses.
+deriving instance Functor f => Functor (Alt f)
+deriving instance Applicative f => Applicative (Alt f)
+deriving instance Monad m => Monad (Alt m)
+deriving instance Alternative f => Alternative (Alt f)
+deriving instance MonadPlus m => MonadPlus (Alt m)
 
 instance Alternative f => Monoid (Alt f a) where
     mempty = Alt empty

--- a/src/Data/Monoid/Compat.hs
+++ b/src/Data/Monoid/Compat.hs
@@ -26,7 +26,7 @@ import Data.Monoid as Base
 import GHC.Generics.Compat ()
 
 #if !MIN_VERSION_base(4,8,0)
-import Control.Applicative (Alternative)
+import Control.Applicative (Alternative(..))
 import Control.Monad (MonadPlus)
 import Prelude.Compat
 

--- a/src/Data/Ord/Compat.hs
+++ b/src/Data/Ord/Compat.hs
@@ -2,12 +2,20 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Data.Ord.Compat (
   module Base
+, Down(..)
 ) where
 import Data.Ord as Base
 
-#if MIN_VERSION_base(4,6,0) && !MIN_VERSION_base(4,7,0)
+#if !MIN_VERSION_base(4,7,0)
 import Prelude.Compat
+#endif
 
+#if MIN_VERSION_base(4,6,0) && !MIN_VERSION_base(4,7,0)
 deriving instance Read a => Read (Down a)
 deriving instance Show a => Show (Down a)
+#elif !MIN_VERSION_base(4,6,0)
+newtype Down a = Down a deriving (Eq, Show, Read)
+
+instance Ord a => Ord (Down a) where
+    compare (Down x) (Down y) = y `compare` x
 #endif

--- a/src/Data/Ord/Compat.hs
+++ b/src/Data/Ord/Compat.hs
@@ -2,6 +2,7 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Data.Ord.Compat (
   module Base
+, Ord(..)
 , Down(..)
 ) where
 import Data.Ord as Base

--- a/src/Data/Version/Compat.hs
+++ b/src/Data/Version/Compat.hs
@@ -2,6 +2,7 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Data.Version.Compat (
   module Base
+, Version(..)
 , makeVersion
 ) where
 import Data.Version as Base

--- a/src/GHC/Generics/Compat.hs
+++ b/src/GHC/Generics/Compat.hs
@@ -11,6 +11,18 @@ module GHC.Generics.Compat (
 ) where
 #else
   module Base
+  -- * Generic representation types
+, U1(..)
+, Par1(..)
+, Rec1(..)
+, K1(..)
+, M1(..)
+, (:+:)(..)
+, (:*:)(..)
+, (:.:)(..)
+  -- * Generic type classes
+, Generic(..)
+, Generic1(..)
 ) where
 import           GHC.Generics as Base
 

--- a/src/System/Console/GetOpt/Compat.hs
+++ b/src/System/Console/GetOpt/Compat.hs
@@ -1,6 +1,9 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module System.Console.GetOpt.Compat (
   module Base
+, ArgOrder(..)
+, OptDescr(..)
+, ArgDescr(..)
 ) where
 import System.Console.GetOpt as Base
 

--- a/test/Data/Monoid/CompatSpec.hs
+++ b/test/Data/Monoid/CompatSpec.hs
@@ -3,6 +3,7 @@ module Data.Monoid.CompatSpec (main, spec) where
 import           Test.Hspec
 import           Test.QuickCheck
 
+import           Control.Applicative
 import           Data.Monoid.Compat
 
 main :: IO ()
@@ -20,3 +21,9 @@ spec = do
   describe "Num (Product a) instance" $
     it "allows a Product value to be created from a number" $
       1 `shouldBe` Product (1 :: Int)
+  describe "Monoid (Alt f a) instance" $
+    it "admits a Monoid from an Alternative instance" $
+      property $ \x y z -> do
+        Alt x <> Alt (empty :: String) `shouldBe` Alt x
+        Alt (empty :: String) <> Alt x `shouldBe` Alt x
+        Alt x <> (Alt y <> Alt z) `shouldBe` (Alt x <> Alt y) <> Alt z

--- a/test/Data/Ord/CompatSpec.hs
+++ b/test/Data/Ord/CompatSpec.hs
@@ -1,0 +1,13 @@
+module Data.Ord.CompatSpec (main, spec) where
+
+import Test.Hspec
+import Data.Ord.Compat
+
+main :: IO ()
+main = hspec spec
+
+spec :: Spec
+spec = do
+  describe "Ord (Down a) instance" $
+    it "reverses the order in which two values are compared" $
+      Down 'a' < Down 'b' `shouldBe` False


### PR DESCRIPTION
I redefined the `Alt` and `Down` ADTs in `Data.Monoid.Compat` and `Data.Ord.Compat`, respectively. I also went back through and exposed some more typeclasses and ADTs in the module headers so that Haddock will pick up on them and make orphan instances more apparent to readers.